### PR TITLE
Prevent missing the jump-in signal with additional threshold check

### DIFF
--- a/sell_and_hold.pl
+++ b/sell_and_hold.pl
@@ -328,7 +328,7 @@ sub calculate_earnings {
             # If this is a new price peak, reset peak and valley.
             if ($price>$series{$starting_date}{'peak'}) {
                 $series{$starting_date}{'peak'} = $price;
-                $series{$starting_date}{'valley'} = $price;
+                $series{$starting_date}{'valley'} = $price if (($price/$series{$starting_date}{'valley'}) <= $VALLEY_THRESHOLD) || $in_market;
             }
 
             # If this is a new valley, reset valley.


### PR DESCRIPTION
@yegg 

Only a problem for earlier years where month to month price changes are more likely to exceed the threshold. 

https://github.com/yegg/s-and-p-timing/issues/1
